### PR TITLE
Allow embedding of ultraviolet in an isolated origin

### DIFF
--- a/src/uv.sw.js
+++ b/src/uv.sw.js
@@ -266,6 +266,9 @@ class UVServiceWorker extends Ultraviolet.EventEmitter {
             if (requestCtx.headers.accept === 'text/event-stream') {
                 responseCtx.headers['content-type'] = 'text/event-stream';
             }
+            if (crossOriginIsolated) {
+                responseCtx.headers['Cross-Origin-Embedder-Policy'] = 'require-corp';
+            }
 
             this.emit('response', resEvent);
             if (resEvent.intercepted) return resEvent.returnValue;


### PR DESCRIPTION
If `Cross-Origin-Embedder-Policy` is set to `require-corp` in the headers of the top page, all embedded frames are also required to have that header set to `require-corp`, or the frame refuses to load. 