### PR TITLE
Remove duplicate check for request prefix

### DIFF
--- a/src/sw.js
+++ b/src/sw.js
@@ -11,13 +11,4 @@ importScripts(__uv$config.sw || 'uv.sw.js');
 
 const uv = new UVServiceWorker();
 
-self.addEventListener('fetch', event => {
-    event.respondWith(
-        (async ()=>{
-            if(event.request.url.startsWith(location.origin + __uv$config.prefix)) {
-                return await uv.fetch(event);
-            }
-            return await fetch(event.request);
-        })()
-    );
-});
+self.addEventListener('fetch', event => { event.respondWith( uv.fetch(event) ) });


### PR DESCRIPTION
As mentioned in this comment on the commit:
https://github.com/titaniumnetwork-dev/Ultraviolet/commit/6ddb73ecd4f2dfb3158771c57ff38d8927dcaf08#r140981857

This check is already performed in the `fetch` method:
https://github.com/titaniumnetwork-dev/Ultraviolet/blob/c34745ffd0c97cd2e190300e57ce9e784474e638/src/uv.sw.js#L50-L58