### PR TITLE
Add credits for CSS rewriting

### DIFF
--- a/src/rewrite/css.js
+++ b/src/rewrite/css.js
@@ -14,6 +14,7 @@ class CSS extends EventEmitter {
         return this.recast(str, options, 'source');
     }
     recast(str, options, type) {
+        // CSS Rewriting from Meteor (https://github.com/meteorproxy/meteor)
         const regex =
         /(@import\s+(?!url\())?\s*url\(\s*(['"]?)([^'")]+)\2\s*\)|@import\s+(['"])([^'"]+)\4/g
 


### PR DESCRIPTION
The CSS rewriting code that was recently added to Ultraviolet was originally from Meteor, which Percs requested to see in a group chat.
This pull request adds proper credits for [Meteor](https://github.com/meteorproxy/meteor) in the CSS rewriter file.